### PR TITLE
Fix: rails_adminをsassと依存関係のないものに修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,6 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
-# Use Sass to process CSS
-# gem "sassc-rails"
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
@@ -79,9 +77,7 @@ gem 'pry-rails'
 gem 'sorcery'
 gem 'ridgepole'
 gem 'rails-i18n'
-gem 'rails_admin', ['>= 3.0.0.rc', '< 4']
-gem "sassc-rails"
+gem 'rails_admin', '~> 3.0'
 gem 'cancancan'
-gem 'font-awesome-sass'
 gem 'config'
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,8 +158,6 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
-    font-awesome-sass (6.2.1)
-      sassc (~> 2.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     hashie (5.0.0)
@@ -333,14 +331,6 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -362,7 +352,6 @@ GEM
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
-    tilt (2.0.11)
     timeout (0.3.1)
     turbo-rails (1.3.2)
       actionpack (>= 6.0.0)
@@ -398,7 +387,6 @@ DEPENDENCIES
   debug
   dotenv-rails
   factory_bot_rails
-  font-awesome-sass
   jbuilder
   jsbundling-rails
   mini_magick
@@ -407,14 +395,13 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4)
   rails-i18n
-  rails_admin (>= 3.0.0.rc, < 4)
+  rails_admin (~> 3.0)
   ridgepole
   rspec-rails
   rubocop
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  sassc-rails
   sorcery
   spring-commands-rspec
   sprockets-rails

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,7 +7,6 @@ class Post < ApplicationRecord
 
   enum status: { draft: 0, archive: 1, publish: 2 }
 
-  has_one :post_body_templates
   belongs_to :user
   has_many :ais, dependent: :destroy
   has_many :aied_users, through: :ais, source: :user


### PR DESCRIPTION
`gem 'rails_admin', '~> 3.0'`に変更